### PR TITLE
Show pts for framenums in debug logs

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -1497,10 +1497,10 @@ bool BuildBlocks(bool recalc)
 //		ValidateBlackFrames(C_a, 3.0, true);
 
 
-    Debug(8, "Black Frame List\n---------------------------\nBlack Frame Count = %i\nnr \tframe\tbright\tuniform\tvolume\t\tcause\tdimcount  bright\n", black_count);
+    Debug(8, "Black Frame List\n---------------------------\nBlack Frame Count = %i\nnr \tframe\tpts\tbright\tuniform\tvolume\t\tcause\tdimcount  bright\n", black_count);
     for (k = 0; k < black_count; k++)
     {
-        Debug(8, "%3i\t%6i\t%6i\t%6i\t%6i\t%6s\t%6i\t%6i\n", k, black[k].frame, black[k].brightness, black[k].uniform, black[k].volume,&(CauseString(black[k].cause)[10]), frame[black[k].frame].dimCount, frame[black[k].frame].hasBright);
+        Debug(8, "%3i\t%6i\t%.3f\t%6i\t%6i\t%6i\t%6s\t%6i\t%6i\n", k, black[k].frame, get_frame_pts(black[k].frame), black[k].brightness, black[k].uniform, black[k].volume,&(CauseString(black[k].cause)[10]), frame[black[k].frame].dimCount, frame[black[k].frame].hasBright);
         if (k+1 < black_count && black[k].frame+1 != black[k+1].frame)
             Debug(8, "-----------------------------\n");
 

--- a/comskip.c
+++ b/comskip.c
@@ -3718,7 +3718,8 @@ scanagain:
                     InsertBlackFrame(j,frame[j].brightness,frame[j].uniform,0, C_l);
                     Debug(
                         3,
-                        "Frame %6i - Cutpoint added when Logo disappears\n",
+                        "Frame %6i (%.3fs) - Cutpoint added when Logo disappears\n",
+                        get_frame_pts(j),
                         j
                     );
                     continue;
@@ -3791,8 +3792,8 @@ scanagain:
                     InsertBlackFrame(cp,frame[cp].brightness,frame[cp].uniform,frame[cp].volume, C_l);
                     Debug(
                         3,
-                        "Frame %6i - Cutpoint added %i seconds after Logo disappears at change percentage of %d\n",
-                        cp, (int)F2L(cp, logo_block[i].end), maxsc
+                        "Frame %6i (%.3fs) - Cutpoint added %i seconds after Logo disappears at change percentage of %d\n",
+                        cp, get_frame_pts(cp), (int)F2L(cp, logo_block[i].end), maxsc
                     );
                 }
             }
@@ -3812,8 +3813,8 @@ scanagain:
                     InsertBlackFrame(j,frame[j].brightness,frame[j].uniform,0, C_l);
                     Debug(
                         3,
-                        "Frame %6i - Cutpoint added when Logo appears\n",
-                        j
+                        "Frame %6i (%.3fs) - Cutpoint added when Logo appears\n",
+                        j, get_frame_pts(j)
                     );
 
                     continue;
@@ -3887,8 +3888,8 @@ scanagain:
                     InsertBlackFrame(cp,frame[cp].brightness,frame[cp].uniform,frame[cp].volume, C_l);
                     Debug(
                         3,
-                        "Frame %6i - Cutpoint added %i seconds before Logo disappears at change percentage of %d\n",
-                        cp, (int)F2L(cp, logo_block[i].end), maxsc
+                        "Frame %6i (%.3fs) - Cutpoint added %i seconds before Logo disappears at change percentage of %d\n",
+                        cp, get_frame_pts(cp), (int)F2L(cp, logo_block[i].end), maxsc
                     );
                 }
             }
@@ -9602,19 +9603,19 @@ bool CheckSceneHasChanged(void)
         if ((brightness <= max_avg_brightness) && hasBright <= maxbright * width * height / 720 / 480 && !isDim /* && uniform < non_uniformity */  /* && !lastLogoTest because logo disappearance is detected too late*/)
         {
             cause |= C_b;
-            Debug(7, "Frame %6i - Black frame with brightness of %i,uniform of %i and volume of %i\n", framenum_real, brightness, uniform, black[black_count-1].volume);
+            Debug(7, "Frame %6i (%.3fs) - Black frame with brightness of %i,uniform of %i and volume of %i\n", framenum_real, get_frame_pts(framenum_real), brightness, uniform, black[black_count-1].volume);
         }
         else if (non_uniformity > 0)
         {
             if ((brightness <= max_avg_brightness) && uniform < non_uniformity )
             {
                 cause |= C_u;
-                Debug(7, "Frame %6i - Black frame with brightness of %i,uniform of %i and volume of %i\n", framenum_real, brightness, uniform, black[black_count-1].volume);
+                Debug(7, "Frame %6i (%.3fs) - Black frame with brightness of %i,uniform of %i and volume of %i\n", framenum_real, get_frame_pts(framenum_real), brightness, uniform, black[black_count-1].volume);
             }
             if (brightness > max_avg_brightness && uniform < non_uniformity && brightness < 180)
             {
                 cause |= C_u;
-                Debug(7, "Frame %6i - Uniform frame with brightness of %i and uniform of %i\n", framenum_real, brightness, uniform);
+                Debug(7, "Frame %6i (%.3fs) - Uniform frame with brightness of %i and uniform of %i\n", framenum_real, get_frame_pts(framenum_real), brightness, uniform);
             }
         }
     }
@@ -9624,7 +9625,7 @@ bool CheckSceneHasChanged(void)
         if ((old_width != 0 && width != old_width) || (old_height != 0 && height != old_height))
         {
             cause |= C_r;
-            Debug(7, "Frame %6i - Resolution change from %d x %d to %d x %d \n", framenum_real, old_width, old_height, width, height);
+            Debug(7, "Frame %6i (%.3fs) - Resolution change from %d x %d to %d x %d \n", framenum_real, get_frame_pts(framenum_real), old_width, old_height, width, height);
             old_width = width;
             old_height = height;
             ResetLogoBuffers();
@@ -9647,12 +9648,12 @@ bool CheckSceneHasChanged(void)
         {
             if (abs(brightness - last_brightness) > brightness_jump)
             {
-                Debug( 7,"Frame %6i - Black frame because large brightness change from %i to %i with uniform %i\n", framenum_real, last_brightness, brightness, uniform);
+                Debug( 7,"Frame %6i (%.3fs) - Black frame because large brightness change from %i to %i with uniform %i\n", framenum_real, get_frame_pts(framenum_real), last_brightness, brightness, uniform);
                 cause |= C_s;
             }
             else if (sceneChangePercent < schange_cutlevel)
             {
-                Debug( 7,"Frame %6i - Black frame because large scene change of %i, uniform %i\n", framenum_real, sceneChangePercent, uniform);
+                Debug( 7,"Frame %6i (%.3fs) - Black frame because large scene change of %i, uniform %i\n", framenum_real, get_frame_pts(framenum_real), sceneChangePercent, uniform);
 
                 cause |= C_s;
             }
@@ -9703,7 +9704,7 @@ bool CheckSceneHasChanged(void)
         schange[schange_count].frame = framenum_real;
         schange_count++;
 //	   memcpy(lastHistogram, histogram, sizeof(histogram));
-        //			Debug(7, "Frame %6i - Scene change with change percentage of %i\n", framenum_real, sceneChangePercent);
+        //			Debug(7, "Frame %6i (%.3fs) - Scene change with change percentage of %i\n", framenum_real, get_frame_pts(framenum_real), sceneChangePercent);
     }
 
     for (i=0; i < 255; i++)


### PR DESCRIPTION
This makes it easier to debug pts based output formats by showing the pts at various events during the comskip lifecycle.