### PR TITLE
Improve accuracy of pts cutpoints

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -1599,14 +1599,12 @@ bool BuildBlocks(bool recalc)
         if (b_count > 0 && v_count > 1.5*b_count)
         {
             b_start = black_start;
-            b_end = black_end;
-            b_counted = b_count;
+            b_end = black_end + v_count;
         }
         else if (b_count == 0 && v_count > 5)
         {
             b_start = b_start - 1 + v_count / 2;
             b_end = b_end + 1 - v_count / 2;
-            b_counted = 3;
         }
         cblock[block_count].cause = cause;
 


### PR DESCRIPTION
This fixes an issue where edl/vdr/ffsplit cutpoints are not correctly synchronized.

For example, here are the black frames detected at a cutpoint with a sample video:

```
-----------------------------
167      33402  1159.875            16       0       4            b          0       0
168      33403  1159.909            16       0       4            b          0       0
169      33404  1159.942            16       0       4        v   b          0       0
170      33405  1159.975            16       0       4        v   b          0       0
171      33406  1160.009            17     372       4        v   b          0       0
172      33407  1160.042            21    1923       4        v           3702       0
173      33408  1160.076            24    4348       4        v           7140      26
174      33409  1160.109            28    7054       4        v           7784      50
175      33410  1160.142            31    9036       4        v          11825      76
176      33411  1160.176            35   11389       4        v          15876      99
177      33412  1160.209            38   13284       4        v          20442     119
178      33413  1160.242            42   15722       4        v          23706     146
179      33414  1160.276            45   17539       4        v          26735     166
180      33415  1160.309            49   19892       4        v          27411     187
181      33416  1160.343            50   20284       4        v          28032     185
-----------------------------
```

Before this change, the generated ffsplit file is:

```
-c copy -ss 24.625 -t 554.821 segment001.ts
-c copy -ss 765.214 -t 259.426 segment002.ts
-c copy -ss 1159.942 -t 443.276 segment003.ts
```

But cutting at 1159.942 would include half a second from the end of the commercial along with the beginning of the show segment.

After this pull request, the generated ffsplit file is as follows:

```
-c copy -ss 24.958 -t 554.054 segment001.ts
-c copy -ss 765.248 -t 258.992 segment002.ts
-c copy -ss 1160.176 -t 442.642 segment003.ts
```

Using these updated cutpoints the resulting segments start on black frames and include no commercial content.