### PR TITLE
Show pts start and end markers in final block list

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -7173,7 +7173,7 @@ bool OutputBlocks(void)
         Debug(1,   "Block list after weighing\n----------------------------------------------------\n", threshold);
         Debug(
             1,
-            "  #     sbf  bs  be     fs     fe    sc      len   scr cmb   ar                   cut bri  logo   vol  sil corr stdev        cc\n"
+            "  #     sbf  bs  be     fs     fe        ts        te       len     sc   scr cmb   ar                   cut    bri logo   vol sil   corr stdev   cc\n"
         );
 
 //		if (output_training) {
@@ -7198,7 +7198,7 @@ bool OutputBlocks(void)
 
             Debug(
                 1,
-                "%3i:%c%c %4i %3i %3i %6i %6i %6.2f %8.3f %5.2f %3i %4.2f %s %4i%c %4.2f %4i%c %2i%c %6.3f %5i %-10s",
+                "%3i:%c%c %4i %3i %3i %6i %6i %8.2fs %8.2fs %8.2fs %6.2f %5.2f %3i %4.2f %s %4i%c %4.2f %4i%c %2i%c %6.3f %5i %-10s",
                 i,
                 CheckFramesForCommercial(cblock[i].f_start+cblock[i].b_head,cblock[i].f_end - cblock[i].b_tail),
                 CheckFramesForReffer(cblock[i].f_start+cblock[i].b_head,cblock[i].f_end - cblock[i].b_tail),
@@ -7207,8 +7207,10 @@ bool OutputBlocks(void)
                 cblock[i].b_tail,
                 cblock[i].f_start,
                 cblock[i].f_end,
-                cblock[i].score,
+                get_frame_pts(cblock[i].f_start),
+                get_frame_pts(cblock[i].f_end),
                 cblock[i].length,
+                cblock[i].score,
 //				cblock[i].schange_count,
                 cblock[i].schange_rate,
                 cblock[i].combined_count,


### PR DESCRIPTION
Adds a `ts` and `te` column to the block list table.

before:

```
Block list after weighing
----------------------------------------------------
  #     sbf  bs  be     fs     fe    sc      len   scr cmb   ar                   cut bri  logo   vol  sil corr stdev        cc
  0:--   13   0  13      1    725   4.00   24.157  0.14   0 1.34          A L    v a b   837+ 0.00 2194+ 94+  0.000    83
  1:++   17  14   3    726   2132   0.01   46.914  0.01   0 1.78            L        b   110- 0.61 2609+ 96+  0.000    11
  2:++    6   4   2   2133  17328   0.00  507.073  0.03   0 1.78           EL       ub   283- 0.93 1825+ 88+  0.000    28
  3:--    5   3   2  17329  17483   5.08    5.138  0.39   4 1.78            LCN     ub  3677+ 0.00 1776- 91+  0.000   367
```

after:

```
Block list after weighing
----------------------------------------------------
  #     sbf  bs  be     fs     fe        ts        te       len     sc   scr cmb   ar                   cut    bri logo   vol sil   corr stdev   cc
  0:--    4   0   4      1    715     0.77s    24.59s    23.82s   2.00  0.12   0 1.78            L        b   881+ 0.00 2224- 950  0.000    88
  1:++    7   4   3    716   2132    24.62s    71.87s    47.25s   0.01  0.02   0 1.78            L        b   136- 0.61 2591+ 950  0.000    13
  2:++    4   4   0   2133   3489    71.91s   117.15s    45.25s   0.03  0.15   0 1.78            L  S   a    1075+ 0.41 2044- 97+  0.000   107
  3:--    1   1   0   3490   3521   117.18s   118.18s     1.00s   2.00  0.00   0 1.78            L        b    31- 0.00    0-  0-  0.000     3
```