### PR TITLE
Add automated builds using TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 os:
   - linux
-sudo: false
-addons:
-  apt:
-    packages:
-      - libargtable2-dev
-      - libavformat-ffmpeg-dev
+before_install:
+  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-dev
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ os: linux
 before_script:
   - sudo add-apt-repository -y ppa:pavlyshko/precise
   - sudo apt-get update -q
-  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-opti-dev
+  - sudo apt-get install -y libargtable2-dev libavformat56-ffmpeg libavformat-ffmpeg-opti-dev
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+os:
+  - linux
+before_install:
+  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-dev
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,8 @@ before_script:
   - sudo apt-get install -y libargtable2-dev ffmpeg-opti libavformat-ffmpeg-opti-dev
 script:
   - make LIBS="-L/opt/ffmpeg/lib" SHLIBS="-lavutil.ffmpeg -lavformat.ffmpeg -lavcodec.ffmpeg -largtable2"
+after_script:
+  - wget https://s3.amazonaws.com/tmm1/ten-copy.mkv
+  - ./comskip ten-copy.mkv
+  - cat ten-copy.txt
+  - grep "9359	17920" ten-copy.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-os:
-  - linux
-before_install:
-  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-dev
+language: c
+os: osx
+before_script:
+  - brew install argtable ffmpeg
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ os: linux
 before_script:
   - sudo add-apt-repository -y ppa:pavlyshko/precise
   - sudo apt-get update -q
-  - sudo apt-get install -y libargtable2-dev libavformat56-ffmpeg libavformat-ffmpeg-opti-dev
+  - sudo apt-get install -y libargtable2-dev ffmpeg-opti
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
-os: osx
+os: linux
 before_script:
-  - brew install argtable ffmpeg
+  - sudo add-apt-repository -y ppa:pavlyshko/precise
+  - sudo apt-get update -q
+  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-opti-dev
 script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: c
 os: linux
 before_script:
   - sudo add-apt-repository -y ppa:pavlyshko/precise
+  - sudo add-apt-repository -y ppa:chris-lea/zeromq
   - sudo apt-get update -q
-  - sudo apt-get install -y libargtable2-dev ffmpeg-opti
-script: make
+  - wget https://launchpad.net/ubuntu/+archive/primary/+files/libfdk-aac0_0.1.1%2B20130514-2_amd64.deb
+  - wget https://launchpad.net/ubuntu/+archive/primary/+files/libopus0_1.0.1-0ubuntu2_amd64.deb
+  - wget https://launchpadlibrarian.net/205263953/libwebp5_0.4.1-1.2pmo1%7Eprecise_amd64.deb
+  - sudo dpkg -i libfdk-aac0_0.1.1+20130514-2_amd64.deb
+  - sudo dpkg -i libopus0_1.0.1-0ubuntu2_amd64.deb
+  - sudo dpkg -i libwebp5_0.4.1-1.2pmo1~precise_amd64.deb
+  - sudo apt-get install -y libargtable2-dev ffmpeg-opti libavformat-ffmpeg-opti-dev
+script:
+  - make LIBS="-L/opt/ffmpeg/lib" SHLIBS="-lavutil.ffmpeg -lavformat.ffmpeg -lavcodec.ffmpeg -largtable2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 os:
   - linux
-before_install:
-  - sudo apt-get install -y libargtable2-dev libavformat-ffmpeg-dev
+sudo: false
+addons:
+  apt:
+    packages:
+      - libargtable2-dev
+      - libavformat-ffmpeg-dev
 script: make

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ ./comskip
 
 #### linux
 
-##### ubuntu 15.04
+##### ubuntu vivid (15.04)
 
 ```
 $ apt-get install -y git
@@ -42,7 +42,7 @@ $ make
 $ ./comskip
 ```
 
-##### ubuntu 14.04
+##### ubuntu trusty (14.04)
 
 ```
 $ add-apt-repository -y ppa:mc3man/trusty-media
@@ -59,6 +59,31 @@ $ cd ..
 $ git clone git://github.com/erikkaashoek/Comskip
 $ cd Comskip
 $ make INCLUDES=-I/opt/ffmpeg/include LIBS="-L/opt/ffmpeg/lib -lavutil -lavformat -lavcodec -ldl -lva -lswscale -lswresample -lsoxr -lvorbis -lbz2 -lz -lxvidcore -lvpx -lx264 -lx265 -lspeex -lfdk-aac -lvorbisenc -lopus -lmp3lame -ldca -lfaac -lopencore-amrnb -lvo-aacenc -lopencore-amrwb -ldcadec"
+
+$ ./comskip
+```
+
+##### ubuntu precise (12.04)
+
+```
+$ add-apt-repository -y ppa:pavlyshko/precise
+$ add-apt-repository -y ppa:chris-lea/zeromq
+$ apt-get update
+
+$ wget https://launchpad.net/ubuntu/+archive/primary/+files/libfdk-aac0_0.1.1%2B20130514-2_amd64.deb
+$ wget https://launchpad.net/ubuntu/+archive/primary/+files/libopus0_1.0.1-0ubuntu2_amd64.deb
+$ wget https://launchpadlibrarian.net/205263953/libwebp5_0.4.1-1.2pmo1%7Eprecise_amd64.deb
+$ dpkg -i libfdk-aac0_0.1.1+20130514-2_amd64.deb
+$ dpkg -i libopus0_1.0.1-0ubuntu2_amd64.deb
+$ dpkg -i libwebp5_0.4.1-1.2pmo1~precise_amd64.deb
+
+$ apt-get install -y git
+$ apt-get install -y build-essential libargtable2-dev
+$ apt-get install -y ffmpeg-opti libavformat-ffmpeg-opti-dev
+
+$ git clone git://github.com/erikkaashoek/Comskip
+$ cd Comskip
+$ make LIBS="-L/opt/ffmpeg/lib" SHLIBS="-lavutil.ffmpeg -lavformat.ffmpeg -lavcodec.ffmpeg -largtable2"
 
 $ ./comskip
 ```


### PR DESCRIPTION
This will build comskip on an Ubuntu Precise machine after every commit and try to run it against a simple sample video file. Should help ensure we don't break linux compatibility as has happened multiple times recently with the addition of threading support, etc.