### PR TITLE
[In-progress] Clang scan-build fixes from static analysis

### DIFF
--- a/ccextratorwin/ccextractor.c
+++ b/ccextratorwin/ccextractor.c
@@ -699,6 +699,10 @@ int add_word (const char *word)
 		new_lower==NULL || new_correct==NULL)
 	{
 		printf ("\rNot enough memory.\n");
+		free(spell_lower);
+		free(spell_correct);
+		free(new_lower);
+		free(new_correct);
 		return -1;
 	}
 	strcpy (new_correct, word);
@@ -713,6 +717,10 @@ int add_word (const char *word)
 	spell_lower[spell_words]=new_lower;
 	spell_correct[spell_words]=new_correct;
 	spell_words++;
+	free(spell_lower);
+	free(spell_correct);
+	free(new_lower);
+	free(new_correct);
 	return 0;
 }
 

--- a/ccextratorwin/myth.c
+++ b/ccextratorwin/myth.c
@@ -865,4 +865,5 @@ void myth_loop(void)
         }
     }
     free (av.data);
+    free (desp);
 }

--- a/comskip.c
+++ b/comskip.c
@@ -7532,12 +7532,19 @@ bool OutputCleanMpg()
 
 #ifdef WIN32
     outf = _creat(outputdirname, _S_IREAD | _S_IWRITE);
-    if(outf<0) return(false);
+    if(outf<0)
+    {
+        free(Buf);
+        return(false);
+    }
     inf = _open(mpegfilename, _O_RDONLY | _O_BINARY);
 #else
     outf = open(outputdirname, O_CREAT | O_TRUNC | O_WRONLY, S_IRUSR | S_IWUSR);
     if(outf<0)
+    {
+        free(Buf);
         return(false);
+    }
 
     infile=myfopen(mpegfilename,"rb");
     inf = fileno(infile);

--- a/comskip.c
+++ b/comskip.c
@@ -12449,6 +12449,7 @@ double FindScoreThreshold(double percentile)
     free(score);
     free(count);
     free(percent);
+    free(start);
     Debug(6, "The %.2f percentile of %i frames is %.2f\n", (percentile * 100.0), totalframes, tempScore);
     return (tempScore);
 }

--- a/comskip.c
+++ b/comskip.c
@@ -12457,6 +12457,7 @@ double FindScoreThreshold(double percentile)
     free(count);
     free(percent);
     free(start);
+    free(blocknr);
     Debug(6, "The %.2f percentile of %i frames is %.2f\n", (percentile * 100.0), totalframes, tempScore);
     return (tempScore);
 }

--- a/comskip.h
+++ b/comskip.h
@@ -2,6 +2,4 @@
 #define COMSKIP
 #endif
 
-#define PACKAGE_STRING " Comskip 0.81.091"
-
 #define _UNICODE

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Comskip], [0.81.089], [https://github.com/erikkaashoek/Comskip/issues])
+AC_INIT([Comskip], [0.81.091], [https://github.com/erikkaashoek/Comskip/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 : ${CFLAGS=""}


### PR DESCRIPTION
Fixing up various errors and warnings found via clang's static analysis.

So far have the potential memory leaks, next up dead assignments and initializations.

Also fixed the version string being defined in multiple places and overridden. Only one place to set it now.