### PR TITLE
bugfix: potential SIGSEGV

### DIFF
--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -2078,15 +2078,15 @@ int main (int argc, char ** argv)
         }
         strncpy(HomeDir, ptr, len);
 
-        len = (size_t)max(0,strrchr(HomeDir,'\\') - HomeDir);
-        if (len==0)
+        ptr = strrchr(HomeDir,'\\');
+        if (!ptr || ptr - HomeDir == 0)
         {
             HomeDir[0] = '.';
             HomeDir[1] = '\0';
         }
         else
         {
-            HomeDir[len] = '\0';
+            *ptr = '\0';
         }
 
         fprintf (stderr, "%s, made using ffmpeg\n", PACKAGE_STRING);


### PR DESCRIPTION
When there is no \ in HomeDir and has an upper address in memory, subtraction in max() can give a positive huge number (two's complement).

I was loading comskip as DSO. DSO addresses are higher in memory layout.

Bug example (in x86_64):
> #include <stdio.h>
#define max(a,b) ((a) > (b)? (a) : (b))
int main() 
{
	  size_t len = (size_t)max(0, (char *)0 - (char *)0xff00000000000000);
	  printf("LEN=%ld\n", len);
	  return 0;
}
