### PR TITLE
Sync configure.ac version with comskip.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Comskip], [0.81.089], [https://github.com/erikkaashoek/Comskip/issues])
+AC_INIT([Comskip], [0.81.098], [https://github.com/erikkaashoek/Comskip/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 : ${CFLAGS=""}


### PR DESCRIPTION
Fixes #50; when compiling Comskip on a Linux environment the version shown is not correct because it's inherited from the configure script instead of **comskip.h** (**PACKAGE_STRING** already defined).