### PR TITLE
Added AM_PROG_CC_C_O for missing legacy source

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,6 +51,7 @@ PKG_CHECK_MODULES(sdl, [sdl >= 1.2.0], has_sdl=yes, has_sdl=no)
 AC_MSG_CHECKING([whether to build the graphical user interface])
 AC_MSG_RESULT([$has_sdl])
 AM_CONDITIONAL([BUILD_GUI], [test "x${has_sdl}" = "xyes"])
+AM_PROG_CC_C_O
 
 AC_CONFIG_FILES(Makefile)
 AC_OUTPUT


### PR DESCRIPTION
Adding AM_PROG_CC_C_O to configure.ac fixes error running autogen.sh on Centos 7.4