### PR TITLE
Sync version in comskip.h with configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([Comskip], [0.81.098], [https://github.com/erikkaashoek/Comskip/issues])
+AC_INIT([Comskip], m4_esyscmd_s([ sed -nre 's/.*PACKAGE_STRING[^0-9.]*([0-9.]*).*/\1/p' comskip.h ]), [https://github.com/erikkaashoek/Comskip/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 : ${CFLAGS=""}


### PR DESCRIPTION
Allows to display the correct program version when running 'autogen' by picking up the version string from comskip.h.