### PR TITLE
Fix loading CC data from CSV

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -14319,7 +14319,7 @@ ccagain:
                 cont = fread(ccData,ccDataLen,1, dump_data_file);
                 if (!cont)
                     break;
-                framenum = ccDataFrame-2;
+                framenum = ccDataFrame;
 #ifdef PROCESS_CC
                 if (processCC) ProcessCCData();
                 if (output_srt || output_smi) process_block(ccData, (int)ccDataLen);


### PR DESCRIPTION
All CC data was off by two frames when loaded from the CSV.

I couldn't find any reason why this should have the `- 2` and without it the resulting log matches one from the `.mpg`.