### PR TITLE
Change precision in CSV

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -13880,10 +13880,12 @@ void OutputFrameArray(bool screenOnly)
         }
         else
         {
-            fprintf(raw, "%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%i,%f,%i,%i",
+            fprintf(raw, "%i,%i,%i,%i,%i,%i,%i,%i,%f,%f,%i,%i,%i,%i,%i,%i,%f,%i,%i",
                     i, frame[i].brightness, frame[i].schange_percent*5, frame[i].logo_present,
-                    frame[i].uniform, frame[i].volume,  frame[i].minY,frame[i].maxY,(int)((frame[i].ar_ratio)*100),
-                    (int)(frame[i].currentGoodEdge * 500), frame[i].isblack,(int)frame[i].cutscenematch,  frame[i].minX,frame[i].maxX,frame[i].hasBright,frame[i].dimCount, frame[i].pts, frame[i].cur_segment, frame[i].audio_channels
+                    frame[i].uniform, frame[i].volume,  frame[i].minY,frame[i].maxY,frame[i].ar_ratio,
+                    frame[i].currentGoodEdge, frame[i].isblack,frame[i].cutscenematch, 
+                    frame[i].minX, frame[i].maxX, frame[i].hasBright, frame[i].dimCount, frame[i].pts, 
+                    frame[i].cur_segment, frame[i].audio_channels
                    );
 #ifdef FRAME_WITH_HISTOGRAM
             for (k = 0; k < 32; k++)
@@ -14198,10 +14200,18 @@ again:
                     if (maxmaxY < frame[frame_count].maxY) maxmaxY = frame[frame_count].maxY;
                     break;
                 case 8:
-                    frame[frame_count].ar_ratio = ((double)strtol(split, NULL, 10))/100;
+                    frame[frame_count].ar_ratio = strtod(split, NULL);
+                    // Handle files that are before the values was written as a double
+                    if (strchr(split, '.') == NULL) {
+                        frame[frame_count].ar_ratio /= 100;
+                    }
                     break;
                 case 9:
-                    frame[frame_count].currentGoodEdge = ((double)strtol(split, NULL, 10))/500;
+                    frame[frame_count].currentGoodEdge = strtod(split, NULL);
+                    // Handle files that are before the values was written as a double
+                    if (strchr(split, '.') == NULL) {
+                        frame[frame_count].currentGoodEdge /= 500;
+                    }
                     break;
                 case 10:
                     frame[frame_count].isblack = strtol(split, NULL, 10);

--- a/comskip.c
+++ b/comskip.c
@@ -13862,7 +13862,7 @@ void OutputFrameArray(bool screenOnly)
         Debug(1, "Could not open raw output file.\n");
         return;
     }
-    fprintf(raw, "sep=,\nframe,brightness,scene_change,logo,uniform,sound,minY,MaxY,ar_ratio,goodEdge,isblack,cutscene, MinX, MaxX, hasBright, Dimcount,PTS,%d",(int)(fps*100+0.5));
+    fprintf(raw, "sep=,\nframe,brightness,scene_change,logo,uniform,sound,minY,MaxY,ar_ratio,goodEdge,isblack,cutscene, MinX, MaxX, hasBright, Dimcount,PTS,%f",fps);
 //	for (k = 0; k < 32; k++) {
 //		fprintf(raw, ",b%3i", k);
 //	}
@@ -14125,12 +14125,24 @@ again:
         fps = t  * 1.00000000000001;
     if (strlen(line) > 131)
     {
-        t = ((double)strtol(&line[131], NULL, 10))/100;
-        if (t > 99)
-            t = t / 10.0;
+        t = strtod(&line[131], NULL);
+
+        // Handle backward compatibility
+        if (strchr(&line[131], '.') == NULL) {
+            t /= 100.0;
+            if (t > 99) {
+                t /= 10.0;
+            }
+
+            if (t>0) {
+                fps = t  * 1.00000000000001;
+            }
+        } else {
+            if (t > 0) {
+                fps = t;
+            }
+        }
     }
-    if (t>0)
-        fps = t  * 1.00000000000001;
     InitComSkip();
     frame_count = 1;
     while (fgets(line, sizeof(line), in_file) != NULL)


### PR DESCRIPTION
Fixes issues where processing a CSV was different than source material.

I've been trying to understand why processing a `.csv` has different results than the source material.

One issue I found was that a frame's `currentGoodEdge` was being evaluated against `logo_threshold`. In some cases the `currentGoodEdge` was `0.800301` in the original frame. When evaluated in `currentGoodEdge > logo_threshold` it would be true, but the CSV only had precision of 2 decimal places which meant that `currentGoodEdge` was only `0.8` and would not evaluate as true.

To prevent these sorts of issues I added a few more decimal places to these columns.