### PR TITLE
Fix compilation with gcc10

### DIFF
--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -161,7 +161,6 @@ int64_t pev_best_effort_timestamp = 0;
 
 int video_stream_index = -1;
 int audio_stream_index = -1;
-int width, height;
 int have_frame_rate ;
 int stream_index;
 


### PR DESCRIPTION
GCC10 has switch -fno-common turned on by default which means each global variable can be defined only once. In this case, width and height variables are defined in comskip.c and mpeg2dec.c. Correct action seems to be to remove declaration from mpeg2dec.c because those two variables are declared with extern a bit lower in the same file anyway.