### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch:
+ - amd64
+ - ppc64le
+
 language: c
 os: linux
 before_script:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/Comskip/builds/198233091

Please have a look.

Regards,
Manish Kumar