### PR TITLE
GHI 135: Corrected build error emitted by AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,8 +12,8 @@ artifacts:
 before_build:
   - git log -1
   - cd C:\projects\comskip
-  - appveyor DownloadFile https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-3.3.1-win64-shared.zip
-  - appveyor DownloadFile https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-3.3.1-win64-dev.zip
+  - appveyor DownloadFile https://github.com/AhiyaHiya/ffmpeg_releases/raw/795b83550a3bc4a42a60c761b1d0fc3900642ec4/ffmpeg-3.3.1-win64-shared.zip
+  - appveyor DownloadFile https://github.com/AhiyaHiya/ffmpeg_releases/raw/795b83550a3bc4a42a60c761b1d0fc3900642ec4/ffmpeg-3.3.1-win64-dev.zip
   - appveyor DownloadFile https://downloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz
 
 build_script:


### PR DESCRIPTION
The appveyor.yml CI build script is broken, because the ffmpeg 3.3.1 files it attempts to download are from a website that no longer exists: https://ffmpeg.zeranoe.com

The ffmpeg 3.3.1 files for Windows x64 were downloaded from the internet archive and pushed to a ffmpeg-release repo on my account.

The script now points to the newly created repo.