### PR TITLE
Add support for 10-bit video

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ before_build:
 build_script:
   - 7z x ffmpeg-4.4.1-full_build-shared.7z
   - C:\msys64\usr\bin\bash -lc "cd /c/projects/comskip && tar xf argtable2-13.tar.gz && cd argtable2-13 && ./configure --build=x86_64-w64-mingw32 && make"
-  - C:\msys64\usr\bin\bash -lc "cd /c/projects/comskip && ./autogen.sh && argtable2_CFLAGS='-Iargtable2-13/src' argtable2_LIBS='-Largtable2-13/src/.libs -largtable2' ffmpeg_CFLAGS='-Iffmpeg-4.4.1-full_build-shared/include' ffmpeg_LIBS='-Lffmpeg-4.4.1-full_build-shared/lib -lavutil -lavformat -lavcodec' ./configure && make"
+  - C:\msys64\usr\bin\bash -lc "cd /c/projects/comskip && ./autogen.sh && argtable2_CFLAGS='-Iargtable2-13/src' argtable2_LIBS='-Largtable2-13/src/.libs -largtable2' ffmpeg_CFLAGS='-Iffmpeg-4.4.1-full_build-shared/include' ffmpeg_LIBS='-Lffmpeg-4.4.1-full_build-shared/lib -lavutil -lavformat -lavcodec -lswscale' ./configure && make"
 
 before_test:
   - C:\msys64\usr\bin\bash -lc "cd /c/projects/comskip && export PATH=$(pwd)/ffmpeg-4.4.1-full_build-shared/bin/:$PATH && ls -alh comskip.exe && ldd comskip.exe"

--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AM_CONDITIONAL([ENABLE_DEBUG], [test "x${enable_debug}" = "xyes"])
 PKG_PROG_PKG_CONFIG
 AS_IF([test "x${enable_static}" = "xyes"], PKG_CONFIG="$PKG_CONFIG --static")
 PKG_CHECK_MODULES(argtable2, [argtable2 >= 2.12])
-PKG_CHECK_MODULES(ffmpeg, [libavutil >= 54.7 libavformat >= 56.4 libavcodec >= 56.1])
+PKG_CHECK_MODULES(ffmpeg, [libavutil >= 54.7 libavformat >= 56.4 libavcodec >= 56.1 libswscale >= 5.0])
 
 AS_IF([test "x${enable_gui}" = "xno"], [
     has_sdl=no

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -904,7 +904,8 @@ int SubmitFrame(AVStream        *video_st, AVFrame         *pFrame , double pts)
 //	bitrate = pFrame->bit_rate;
     if (pFrame->linesize[0] > MAXWIDTH || pFrame->height > MAXHEIGHT || pFrame->linesize[0] < 100 || pFrame->height < 100)
     {
-        //				printf("Panic: illegal height, width or frame period\n");
+        Debug(1, "Panic: illegal height (%d), width (%d) or frame period (%d)\n",
+              pFrame->height, pFrame->width, pFrame->linesize[0]);
         frame_ptr = NULL;
         return(0);
     }


### PR DESCRIPTION
Uses swscale to convert to 8-bit, because `SubmitFrame` uses `frame_ptr = pFrame->data[0];` and assumes `unsigned char *frame_ptr` meaning 8-bit per pixel.