### PR TITLE
Update Comskip repository link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add python ffmpeg tzdata bash \
 && wget http://prdownloads.sourceforge.net/argtable/argtable2-13.tar.gz \
 && tar xzf argtable2-13.tar.gz \
 && cd argtable2-13/ && ./configure && make && make install \
-&& cd /tmp && git clone git://github.com/erikkaashoek/Comskip.git \
+&& cd /tmp && git clone https://github.com/erikkaashoek/Comskip \
 && cd Comskip && ./autogen.sh && ./configure && make && make install \
 && apk del builddeps \
 && rm -rf /var/cache/apk/* /tmp/* /tmp/.[!.]*


### PR DESCRIPTION
git:// protocol is no longer supported, replaced with https://

```
#6 17.09 Cloning into 'Comskip'...
#6 17.37 fatal: remote error:
#6 17.37   The unauthenticated git protocol on port 9418 is no longer supported.
#6 17.37 Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```