### PR TITLE
Update to modern ffmpeg codec APIs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -49,7 +49,7 @@ AM_CONDITIONAL([ENABLE_DEBUG], [test "x${enable_debug}" = "xyes"])
 PKG_PROG_PKG_CONFIG
 AS_IF([test "x${enable_static}" = "xyes"], PKG_CONFIG="$PKG_CONFIG --static")
 PKG_CHECK_MODULES(argtable2, [argtable2 >= 2.12])
-PKG_CHECK_MODULES(ffmpeg, [libavutil >= 54.7 libavformat >= 56.4 libavcodec >= 56.1 libswscale >= 5.0])
+PKG_CHECK_MODULES(ffmpeg, [libavutil >= 54.7 libavformat >= 57.33.100 libavcodec >= 57.37.100 libswscale >= 5.0])
 
 AS_IF([test "x${enable_gui}" = "xno"], [
     has_sdl=no

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -1822,6 +1822,7 @@ int stream_component_open(VideoState *is, int stream_index)
     case AVMEDIA_TYPE_VIDEO:
         is->videoStream = stream_index;
         is->video_st = pFormatCtx->streams[stream_index];
+        is->dec_ctx = codecCtx;
 
 //          is->frame_timer = (double)av_gettime() / 1000000.0;
 //          is->frame_last_delay = 40e-3;

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -741,7 +741,7 @@ void audio_packet_process(VideoState *is, AVPacket *pkt)
  //       else
  //           avcodec_get_frame_defaults(is->frame);
 
-        len1 = avcodec_decode_audio4(is->audio_st->codec, is->frame, &got_frame, pkt_temp);
+        len1 = avcodec_decode_audio4(is->audio_ctx, is->frame, &got_frame, pkt_temp);
 
         if (prev_codec_id != -1 && (unsigned int)prev_codec_id != is->audio_st->codecpar->codec_id)
         {
@@ -1069,7 +1069,7 @@ again:
     {
         if(is->audioStream >= 0)
         {
-            avcodec_flush_buffers(is->audio_st->codec);
+            avcodec_flush_buffers(is->audio_ctx);
         }
         if(is->videoStream >= 0)
         {

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -94,7 +94,7 @@ typedef struct VideoPicture
 typedef struct VideoState
 {
     AVFormatContext *pFormatCtx;
-    AVCodecContext *dec_ctx;
+    AVCodecContext *dec_ctx, *audio_ctx, *subtitle_ctx;
     int             videoStream, audioStream, subtitleStream;
 
     int             av_sync_type;
@@ -1797,12 +1797,14 @@ int stream_component_open(VideoState *is, int stream_index)
     case AVMEDIA_TYPE_SUBTITLE:
         is->subtitleStream = stream_index;
         is->subtitle_st = pFormatCtx->streams[stream_index];
+        is->subtitle_ctx = codecCtx;
         if (demux_pid)
             selected_subtitle_pid = is->subtitle_st->id;
         break;
     case AVMEDIA_TYPE_AUDIO:
         is->audioStream = stream_index;
         is->audio_st = pFormatCtx->streams[stream_index];
+        is->audio_ctx = codecCtx;
 //          is->audio_buf_size = 0;
 //          is->audio_buf_index = 0;
 

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -2105,13 +2105,13 @@ void file_close()
 //    av_freep(&ist->hwaccel_device);
 
 
-    if (is->videoStream != -1) avcodec_close(is->pFormatCtx->streams[is->videoStream]->codec);
+    if (is->dec_ctx) avcodec_close(is->dec_ctx);
     is->videoStream = -1;
 //    avcodec_free_context(&is->pFormatCtx->streams[is->videoStream]->codec);
 
-    if (is->audioStream != -1) avcodec_close(is->pFormatCtx->streams[is->audioStream]->codec);
+    if (is->audio_ctx) avcodec_close(is->audio_ctx);
     is->audioStream = -1;
-    if (is->subtitleStream != -1)  avcodec_close(is->pFormatCtx->streams[is->subtitleStream]->codec);
+    if (is->subtitle_ctx)  avcodec_close(is->subtitle_ctx);
     is->subtitleStream = -1;
 //    is->pFormatCtx = NULL;
 

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -1652,8 +1652,8 @@ int stream_component_open(VideoState *is, int stream_index)
 
     AVFormatContext *pFormatCtx = is->pFormatCtx;
     AVCodecContext *codecCtx;
-    AVCodec *codec;
-    AVCodec *codec_hw = NULL;
+    const AVCodec *codec;
+    const AVCodec *codec_hw = NULL;
 
 
 

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -1667,11 +1667,9 @@ int stream_component_open(VideoState *is, int stream_index)
 
     // Get a pointer to the codec context for the video stream
 
-    codecCtx = pFormatCtx->streams[stream_index]->codec;
     codecPar = pFormatCtx->streams[stream_index]->codecpar;
-    avcodec_close(codecCtx);
 
-	codec = avcodec_find_decoder(codecCtx->codec_id);
+	codec = avcodec_find_decoder(codecPar->codec_id);
 
     if (use_dxva2 && !codec_hw) {
 		if (codecPar->codec_id == AV_CODEC_ID_MPEG2VIDEO) codec_hw = avcodec_find_decoder_by_name("mpeg2_dxva2");
@@ -1710,6 +1708,9 @@ int stream_component_open(VideoState *is, int stream_index)
         fprintf(stderr, "Using Codec: %s instead of %s\n", codec_hw->name, codec->name);
         codec = codec_hw;
     }
+
+    codecCtx = avcodec_alloc_context3(codec);
+    avcodec_parameters_to_context(codecCtx, codecPar);
 
     if (codecCtx->codec_type == AVMEDIA_TYPE_VIDEO)
     {
@@ -2105,13 +2106,13 @@ void file_close()
 //    av_freep(&ist->hwaccel_device);
 
 
-    if (is->dec_ctx) avcodec_close(is->dec_ctx);
+    if (is->dec_ctx) avcodec_free_context(&is->dec_ctx);
     is->videoStream = -1;
 //    avcodec_free_context(&is->pFormatCtx->streams[is->videoStream]->codec);
 
-    if (is->audio_ctx) avcodec_close(is->audio_ctx);
+    if (is->audio_ctx) avcodec_free_context(&is->audio_ctx);
     is->audioStream = -1;
-    if (is->subtitle_ctx)  avcodec_close(is->subtitle_ctx);
+    if (is->subtitle_ctx)  avcodec_free_context(&is->subtitle_ctx);
     is->subtitleStream = -1;
 //    is->pFormatCtx = NULL;
 


### PR DESCRIPTION
Partly derived from #150; fixes #142. Seems to work in my experimenting, but I don't have a broad test suite for this; in particular, this likely breaks some of the AC3-specific code (I have no idea what that code is supposed to do, whether or not it's still relevant with modern ffmpeg, or how to test it).

This works with both lavf/lavc≤58 and lavf/lavc≥59, but requires at least lavf 57.33.100 / lavc 57.37.100 (versions from 2016).