### PR TITLE
NVidia Jetson Nano hardware support

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -468,6 +468,10 @@ int                     hardware_decode = 0;
 int                     use_cuvid = 0;
 int                     use_vdpau = 0;
 int                     use_dxva2 = 0;
+#ifdef ENABLE_JETSONNANO
+int                     use_nvmpi = 0;
+int                     use_nvv4l2dec = 0;
+#endif
 int						skip_B_frames = 0;
 int						lowres = 0;
 bool					live_tv = false;
@@ -8767,6 +8771,10 @@ FILE* LoadSettings(int argc, char ** argv)
     struct arg_lit*		cl_use_cuvid			= arg_lit0(NULL, "cuvid", "Use NVIDIA Video Decoder (CUVID), if available");
     struct arg_lit*		cl_use_vdpau			= arg_lit0(NULL, "vdpau", "Use NVIDIA Video Decode and Presentation API (VDPAU), if available");
     struct arg_lit*		cl_use_dxva2			= arg_lit0(NULL, "dxva2", "Use DXVA2 Video Decode and Presentation API (DXVA2), if available");
+#ifdef ENABLE_JETSONNANO
+    struct arg_lit*     cl_use_nvmpi            = arg_lit0(NULL, "nvmpi",  "Use NVIDIA Video Decoder (NVMPI), if available");
+    struct arg_lit*     cl_use_nvv4l2dec        = arg_lit0(NULL, "nvv4l2dec", "Use NVIDIA Video Decoder (NVV4L2), if available");
+#endif
     struct arg_lit*		cl_list_decoders		= arg_lit0(NULL, "decoders", "List all decoders and exit");
     struct arg_int*		cl_threads				= arg_int0(NULL, "threads", "<int>", "The number of threads to use");
     struct arg_int*		cl_verbose				= arg_intn("v", "verbose", NULL, 0, 1, "Verbose level");
@@ -8797,6 +8805,10 @@ FILE* LoadSettings(int argc, char ** argv)
         cl_use_cuvid,
         cl_use_vdpau,
         cl_use_dxva2,
+#ifdef ENABLE_JETSONNANO
+        cl_use_nvmpi,
+        cl_use_nvv4l2dec,
+#endif
         cl_list_decoders,
         cl_threads,
         cl_pid,
@@ -9258,6 +9270,18 @@ FILE* LoadSettings(int argc, char ** argv)
         printf("Enabling use_dxva2\n");
         use_dxva2 = 1;
     }
+#ifdef ENABLE_JETSONNANO
+    if (cl_use_nvmpi->count)
+    {
+        printf("Enabling use_nvmpi\n");
+        use_nvmpi = 1;
+    }
+    if (cl_use_nvv4l2dec->count)
+    {
+        printf("Enabling use_nvv4l2dec\n");
+        use_nvv4l2dec = 1;
+    }
+#endif
 
     if (cl_threads->count)
     {

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,15 @@ AC_MSG_CHECKING([whether to build with debugging options enabled])
 AS_IF([test "x${enable_debug}" = "xyes"], AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
 AM_CONDITIONAL([ENABLE_DEBUG], [test "x${enable_debug}" = "xyes"])
 
+AC_ARG_ENABLE([jetsonnano], [AS_HELP_STRING([--enable-jetsonnano], [build with NVidia Jetson Nano specific hardware accelerations])])
+AC_MSG_CHECKING([whether to build with Jetson Nano specific hardware accelerations])
+AS_IF([test "x${enable_jetsonnano}" = "xyes"], AC_MSG_RESULT([yes]), AC_MSG_RESULT([no]))
+AM_CONDITIONAL([ENABLE_JETSONNANO], [test "x${enable_jetsonnano}" = "xyes"])
+
+AS_IF([test "x${enable_jetsonnano}" = "xyes"],[
+  AC_DEFINE(ENABLE_JETSONNANO)
+])
+
 PKG_PROG_PKG_CONFIG
 AS_IF([test "x${enable_static}" = "xyes"], PKG_CONFIG="$PKG_CONFIG --static")
 PKG_CHECK_MODULES(argtable2, [argtable2 >= 2.12])

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -68,6 +68,10 @@ extern int      hardware_decode;
 extern int      use_cuvid;
 extern int      use_vdpau;
 extern int      use_dxva2;
+#ifdef ENABLE_JETSONNANO
+extern int      use_nvmpi;
+extern int      use_nvv4l2dec;
+#endif
 int av_log_level=AV_LOG_INFO;
 
 
@@ -1687,6 +1691,28 @@ int stream_component_open(VideoState *is, int stream_index)
 		if (codecPar->codec_id == AV_CODEC_ID_MPEG4) codec_hw = avcodec_find_decoder_by_name("mpeg4_cuvid");
 		if (codecPar->codec_id == AV_CODEC_ID_VC1) codec_hw = avcodec_find_decoder_by_name("vc1_cuvidl");
     }
+
+#ifdef ENABLE_JETSONNANO
+    if (use_nvmpi && !codec_hw) {
+      if (codecPar->codec_id == AV_CODEC_ID_MPEG2VIDEO) codec_hw = avcodec_find_decoder_by_name("mpeg2_nvmpi");
+      if (codecPar->codec_id == AV_CODEC_ID_H264)       codec_hw = avcodec_find_decoder_by_name("h264_nvmpi");
+      if (codecPar->codec_id == AV_CODEC_ID_HEVC)       codec_hw = avcodec_find_decoder_by_name("hevc_nvmpi");
+      if (codecPar->codec_id == AV_CODEC_ID_MPEG4)      codec_hw = avcodec_find_decoder_by_name("mpeg4_nvmpi");
+
+      if (codecPar->codec_id == AV_CODEC_ID_VP8)        codec_hw = avcodec_find_decoder_by_name("vp8_nvmpi");
+      if (codecPar->codec_id == AV_CODEC_ID_VP9)        codec_hw = avcodec_find_decoder_by_name("vp9_nvmpi");
+    }
+
+    if (use_nvv4l2dec && !codec_hw) {
+      if (codecPar->codec_id == AV_CODEC_ID_MPEG2VIDEO) codec_hw = avcodec_find_decoder_by_name("mpeg2_nvv4l2dec");
+      if (codecPar->codec_id == AV_CODEC_ID_H264)       codec_hw = avcodec_find_decoder_by_name("h264_nvv4l2dec");
+      if (codecPar->codec_id == AV_CODEC_ID_HEVC)       codec_hw = avcodec_find_decoder_by_name("hevc_nvv4l2dec");
+      if (codecPar->codec_id == AV_CODEC_ID_MPEG4)      codec_hw = avcodec_find_decoder_by_name("mpeg4_nvv4l2dec");
+
+      if (codecPar->codec_id == AV_CODEC_ID_VP8)        codec_hw = avcodec_find_decoder_by_name("vp8_nvv4l2dec");
+      if (codecPar->codec_id == AV_CODEC_ID_VP9)        codec_hw = avcodec_find_decoder_by_name("vp9_nvv4l2dec");
+    }
+#endif
 
 	// If decoding in hardware try if running on a Raspberry Pi and then use it's decoder instead.
     if (hardware_decode && !codec_hw) {


### PR DESCRIPTION
Added some config options which enable use of:
* nvmpi
* nvv4l2dev
on Jetson (Nano) hardware.

This requires a patched ffmpeg version:
https://github.com/jocover/jetson-ffmpeg
or
https://github.com/LinusCDE/mad-jetson-ffmpeg