### PR TITLE
Initialize dominant_ac also for ac_wrong_modifier

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -4363,6 +4363,11 @@ scanagain:
     frame[frame_count].hasBright = 0;
     InsertBlackFrame(frame_count,0,0,0, C_b);
 
+    if (cut_on_ac_change || ac_wrong_modifier != 0) {
+        FillACHistogram(true);
+        dominant_ac = ac_histogram[0].audio_channels;
+    }
+
     if (cut_on_ac_change)
     {
         if (ac_block[ac_block_count].start > 0)
@@ -4371,9 +4376,6 @@ scanagain:
             ac_block[ac_block_count].end = frame_count;
             ac_block_count++;
         }
-
-        FillACHistogram(true);
-        dominant_ac = ac_histogram[0].audio_channels;
 
         // Print out ar cblock list
         Debug(4, "\nPrinting AC cblock list\n-----------------------------------------\n");


### PR DESCRIPTION
I don't use cut_on_ac_change but I still use ac_wrong_modifier because it provides a pretty accurate weight.

Before, dominant_ac was only initialized when cut_on_ac_change was enabled. If it didn't it was incorrectly reported as 0:
`
Block 0 audio_channels (6) is different from dominant audio_channels (0).
Block 0 score:  Before - 0.50   After - 2.50
`

(I hope it's clear what I mean)

My patch seems to work but I don't know the codebase well so there might be a better way to do this.