### PR TITLE
Add Intel Quick Sync Video acceleration (QSV) support

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -468,6 +468,7 @@ int                     hardware_decode = 0;
 int                     use_cuvid = 0;
 int                     use_vdpau = 0;
 int                     use_dxva2 = 0;
+int                     use_qsv = 0;
 int						skip_B_frames = 0;
 int						lowres = 0;
 bool					live_tv = false;
@@ -8767,6 +8768,7 @@ FILE* LoadSettings(int argc, char ** argv)
     struct arg_lit*		cl_use_cuvid			= arg_lit0(NULL, "cuvid", "Use NVIDIA Video Decoder (CUVID), if available");
     struct arg_lit*		cl_use_vdpau			= arg_lit0(NULL, "vdpau", "Use NVIDIA Video Decode and Presentation API (VDPAU), if available");
     struct arg_lit*		cl_use_dxva2			= arg_lit0(NULL, "dxva2", "Use DXVA2 Video Decode and Presentation API (DXVA2), if available");
+    struct arg_lit*		cl_use_qsv				= arg_lit0(NULL, "qsv", "Use Intel Quick Sync Video acceleration (QSV), if available");
     struct arg_lit*		cl_list_decoders		= arg_lit0(NULL, "decoders", "List all decoders and exit");
     struct arg_int*		cl_threads				= arg_int0(NULL, "threads", "<int>", "The number of threads to use");
     struct arg_int*		cl_verbose				= arg_intn("v", "verbose", NULL, 0, 1, "Verbose level");
@@ -8797,6 +8799,7 @@ FILE* LoadSettings(int argc, char ** argv)
         cl_use_cuvid,
         cl_use_vdpau,
         cl_use_dxva2,
+        cl_use_qsv,
         cl_list_decoders,
         cl_threads,
         cl_pid,
@@ -9257,6 +9260,12 @@ FILE* LoadSettings(int argc, char ** argv)
     {
         printf("Enabling use_dxva2\n");
         use_dxva2 = 1;
+    }
+
+    if (cl_use_qsv->count)
+    {
+        printf("Enabling use_qsv\n");
+        use_qsv = 1;
     }
 
     if (cl_threads->count)

--- a/mpeg2dec.c
+++ b/mpeg2dec.c
@@ -56,6 +56,9 @@ const HWAccel hwaccels[] = {
 #if CONFIG_VDA
     { "vda",   vda_init,   HWACCEL_VDA,   AV_PIX_FMT_VDA },
 #endif
+#if HAVE_QSV
+    { "qsv",   qsv_init,   HWACCEL_QSV,   AV_PIX_FMT_QSV },
+#endif
     { 0 },
 };
 
@@ -68,6 +71,7 @@ extern int      hardware_decode;
 extern int      use_cuvid;
 extern int      use_vdpau;
 extern int      use_dxva2;
+extern int      use_qsv;
 int av_log_level=AV_LOG_INFO;
 
 
@@ -1663,6 +1667,17 @@ int stream_component_open(VideoState *is, int stream_index)
     codecPar = pFormatCtx->streams[stream_index]->codecpar;
 
 	codec = avcodec_find_decoder(codecPar->codec_id);
+
+    if (use_qsv && !codec_hw) {
+		if (codecPar->codec_id == AV_CODEC_ID_MJPEG) codec_hw = avcodec_find_decoder_by_name("mjpeg_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_MPEG2VIDEO) codec_hw = avcodec_find_decoder_by_name("mpeg2_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_H264) codec_hw = avcodec_find_decoder_by_name("h264_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_VC1) codec_hw = avcodec_find_decoder_by_name("vc1_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_HEVC) codec_hw = avcodec_find_decoder_by_name("hevc_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_AV1) codec_hw = avcodec_find_decoder_by_name("av1_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_VP8) codec_hw = avcodec_find_decoder_by_name("vp8_qsv");
+		if (codecPar->codec_id == AV_CODEC_ID_VP9) codec_hw = avcodec_find_decoder_by_name("vp9_qsv");
+    }
 
     if (use_dxva2 && !codec_hw) {
 		if (codecPar->codec_id == AV_CODEC_ID_MPEG2VIDEO) codec_hw = avcodec_find_decoder_by_name("mpeg2_dxva2");


### PR DESCRIPTION
Add support for Intel Quick Sync Video acceleration.

Tested on an Intel i5-12400T with [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg)