### PR TITLE
Fix close_data segfault when output_data is not set

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -16516,8 +16516,11 @@ void dump_data(char *start, int length)
 
 void close_data()
 {
+    if (output_data)
+    {
 	if (dump_data_file) {
 		fclose(dump_data_file);
 		dump_data_file = 0;
 	}
+    }
 }


### PR DESCRIPTION
I was receiving segfaults and determined it was due to trying to close the dump_data_file that was never set. I am assuming there was an option I didn't have set, but this seems like a better fix.