### PR TITLE
Update package version - required for brew formula submission

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,18 +39,18 @@ jobs:
     - name: Configure Brew packages ffmpeg7
       if: ${{ matrix.ffmpeg_version == 'ffmpeg7' }}
       run: |
-        brew install autoconf automake libtool pkgconf argtable ffmpeg sdl12-compat
+        brew install autoconf automake libtool pkgconf argtable ffmpeg sdl2
 
     - name: Configure Brew packages ffmpeg6
       if: ${{ matrix.ffmpeg_version == 'ffmpeg6' }}
       run: |
-        brew install autoconf automake libtool pkgconf argtable ffmpeg@6 sdl12-compat
+        brew install autoconf automake libtool pkgconf argtable ffmpeg@6 sdl2
         brew link ffmpeg@6
 
     - name: Configure Brew packages ffmpeg5
       if: ${{ matrix.ffmpeg_version == 'ffmpeg5' }}
       run: |
-        brew install autoconf automake libtool pkgconf argtable ffmpeg@5 sdl12-compat
+        brew install autoconf automake libtool pkgconf argtable ffmpeg@5 sdl2
         brew link ffmpeg@5
 
     - name: Setup msys2

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ First install Xcode (freely available from the Mac OS X App Store). After it's i
 The easiest way to install Comskip's dependencies is via Homebrew (http://brew.sh/):
 
 ```
-$ brew install autoconf automake libtool pkgconf argtable ffmpeg sdl12-compat
+$ brew install autoconf automake libtool pkgconf argtable ffmpeg sdl2
 ```
 
 [Macports](https://www.macports.org/install.php) natively compiles all libraries from source. The project [etv-comskip](https://github.com/essandess/etv-comskip) has an example [Makefile](https://github.com/essandess/etv-comskip/blob/master/Makefile) using Macports tools.

--- a/comskip.h
+++ b/comskip.h
@@ -2,7 +2,7 @@
 #define COMSKIP
 #endif
 #ifdef _WIN32
-#define PACKAGE_STRING " Comskip 0.82.011"
+#define PACKAGE_STRING " Comskip 0.83.001"
 #endif
 #define _UNICODE
 


### PR DESCRIPTION
Originally I used the test from the appveyor job on this repo, but the guys at brew suggested a simpler test including checking the version number from the CLI. The tagged release did not include a package number change, so the test currently fails. The second commit corrects this.

The first commit is a change required by the brew checkers.

Here is the brew formula PR: https://github.com/Homebrew/homebrew-core/pull/209523

Once this is merged, another github release will be needed for `comskip-0.83.001`. The the CLI should match the brew test. @erikkaashoek if a different process needs to be followed to update the package version or the numbering needs to be different please let me know.

@tmm1 FYI