### PR TITLE
Fix to ignore comments in ini file when parsing. 

### DIFF
--- a/comskip.c
+++ b/comskip.c
@@ -8470,9 +8470,34 @@ void LoadIniFile()
     if (ini_file)
     {
         printf("Using %s for initiation values.\n", inifilename);
-        len = fread(data, 1, 59999, ini_file);
-        fclose(ini_file);
+        {
+            char line[2048];
+            len = 0;
+            while (fgets(line, sizeof(line), ini_file) && len < 59998)
+            {
+                char *p = line;
+                int in_quote = 0;
+                while (*p)
+                {
+                    if (in_quote && *p == '\\') { p += 2; continue; }
+                    if (*p == '"') { in_quote = !in_quote; p++; continue; }
+                    if (!in_quote && (*p == ';' || *p == '#'))
+                    {
+                        *p++ = '\n';
+                        *p   = '\0';
+                        break;
+                    }
+                    p++;
+                }
+                size_t ll = strlen(line);
+                if (len + ll > 59998) break;
+                memcpy(data + len, line, ll);
+                len += ll;
+            }
+            fclose(ini_file);
+        }
         data[len] = '\0';
+
         ini_text[0] = 0;
         AddIniString("[Main Settings]\n");
         AddIniString(";the sum of the values for which kind of frames comskip will consider as possible cutpoints: 1=uniform (black or any other color) frame, 2=logo, 4=scene change, 8=resolution change, 16=closed captions, 32=aspect ration, 64=silence, 255=all.\n");


### PR DESCRIPTION
I ran into this issue, driving myself crazy in the process, of certain changes I made not taking effect or causing unexpected results. 

Turns out, because I like to add lots of comments of things I was trying in the comskip.ini file, the values **IN** those comments were being honored due to how comskip parses the ini file. So this avoids issues if you have a comment with a legit name/value pair  like:  "intelligent_brightness=1 ; don't set global_threshold=0, it doesn't work well" etc...

Code changes compiled and tested locally.  

_Though straight forward, please give this PR extra scrunty.  Given this is my 1st commit to this project and though a 30+ year developer, C/C++ is not my "1st" language :-)_ 